### PR TITLE
feat: use localStorage to store chatHistory's data

### DIFF
--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -12,7 +12,7 @@ import { ChangeEvent, useState, KeyboardEvent } from "react"
 import { useAutoScrollToBottom } from "../../utils/useAutoScrollToBottom.ts"
 import { Message } from "../../types/message.ts"
 import { DEFAULT_MSG } from "../../constant/message.ts"
-import { useLocalStorage } from "../../utils/useLocalStorage.ts"
+import { useSessionStorage } from "../../utils/useSessionStorage.ts"
 
 type Props = {
   onChatActivation: () => void
@@ -21,8 +21,8 @@ type Props = {
 const ChatWindow = ({ onChatActivation }: Props) => {
   const [message, setMessage] = useState<string>("")
 
-  // custom hook useLocalStorage is used to set initial value for previous chat, if there is no chat, it uses default DEFAULT_MSG as initial value. Then whenever there is new chatHistory, it is stored in localStorage
-  const [chatHistory, setChatHistory] = useLocalStorage<Message[]>(
+  // custom hook useSessionStorage is used to set initial value for previous chat, if there is no chat, it uses default DEFAULT_MSG as initial value. Then whenever there is new chatHistory, it is stored in sessionStorage
+  const [chatHistory, setChatHistory] = useSessionStorage<Message[]>(
     DEFAULT_MSG,
     "chatHistory"
   )

--- a/src/utils/useSessionStorage.ts
+++ b/src/utils/useSessionStorage.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect } from "react"
 
-export function useLocalStorage<T>(
+export function useSessionStorage<T>(
   initialState: T,
   keyName: string
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [value, setValue] = useState<T>(() => {
-    const item = localStorage.getItem(keyName)
+    const item = sessionStorage.getItem(keyName)
     return item ? JSON.parse(item) : initialState
   })
 
   useEffect(() => {
-    localStorage.setItem(keyName, JSON.stringify(value))
+    sessionStorage.setItem(keyName, JSON.stringify(value))
   }, [value, keyName])
 
   return [value, setValue]


### PR DESCRIPTION
### Issues
<!--- - List of the full links to the related Asana tickets or related PRs -->
[Asana: [FE] Store chatHistory data after close chatWindow](https://app.asana.com/0/1207095790604387/1207150710592931/f)

### Updated
<!---  - Summary what did you update to fix this issue  -->
<!---  - Or a summary of what you did to implement this feature  -->
- create custom hook `useLocalStorage` to store `chatHistory`'s data, provide initial value for `chatHistory` from `localStorage`, if there is no data in `localStorage`, use default message `DEFAULT_MSG`
- Change from using `useState` for `chatHistory` to use `useLocalStorage`.

### Result
<!-- Screenshot or video of the UI, API doc, or the result as the proof of work for this PR -->
https://github.com/AI-ChatBot-Yoga/ai-chatbot/assets/133303660/92c1d831-c1bb-4bce-bb74-2e8a90696aa3



<!--- If there's a way to test this fix please list it here
### How to test
- Step 1: List all steps to test this PR
-->
