### PR TITLE
feat: get response from API and display on UI as bot's message

### DIFF
--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -56,6 +56,14 @@ const ChatWindow = ({ onChatActivation }: Props) => {
 
       // TODO: Vu - Please handle the response answer from the LLM and return it to the UI
       console.log("response", response)
+      // setMessageBot(response.output)
+
+      const newMessage = {
+        message: response.output,
+        sender: "bot",
+      }
+
+      setChatHistory((chatHistory) => [...chatHistory, newMessage])
     } catch (error) {
       console.error("Error sending message:", error)
     }

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -4,11 +4,9 @@ import { IconSend2, IconReload, IconX } from "@tabler/icons-react"
 import { Box, Paper, TextInput, Text, ScrollArea } from "@mantine/core"
 import { ChangeEvent, useState, KeyboardEvent } from "react"
 import { useAutoScrollToBottom } from "@/utils/useAutoScrollToBottom"
-import { Message } from "@/types/message"
-import { DEFAULT_MSG } from "@/constant/message"
-import { useSessionStorage } from "@/utils/useSessionStorage"
 import ConfirmationModal from "@/components/ConfirmationModal"
 import { ChatAPI } from "@/apis/chat"
+import { useChatHistory } from "@/utils/useChatHistory"
 
 type Props = {
   onChatActivation: () => void
@@ -23,11 +21,9 @@ const ChatWindow = ({ onChatActivation }: Props) => {
   // this hook is used for Modal component (ConfirmationModal)
   const [openedModal, { open, close }] = useDisclosure(false)
 
-  // custom hook useSessionStorage is used to set initial value for previous chat, if there is no chat, it uses default DEFAULT_MSG as initial value. Then whenever there is new chatHistory, it is stored in sessionStorage
-  const [chatHistory, setChatHistory] = useSessionStorage<Message[]>(
-    DEFAULT_MSG,
-    "chatHistory"
-  )
+  // custom hook to manage chat history
+  const { chatHistory, addMessageToChatHistory, clearChatHistory } =
+    useChatHistory()
 
   // Auto scroll to bottom when there is new message
   const viewport = useAutoScrollToBottom(chatHistory)
@@ -37,12 +33,7 @@ const ChatWindow = ({ onChatActivation }: Props) => {
     if (!message) return
 
     if (message.trim() !== "") {
-      const newMessage = {
-        message,
-        sender: "user",
-      }
-
-      setChatHistory((chatHistory) => [...chatHistory, newMessage])
+      addMessageToChatHistory(message, "user")
       setMessage("")
     }
 
@@ -54,16 +45,9 @@ const ChatWindow = ({ onChatActivation }: Props) => {
         command: message,
       })
 
-      // TODO: Vu - Please handle the response answer from the LLM and return it to the UI
+      // Handle the response from the server and update chat history
       console.log("response", response)
-      // setMessageBot(response.output)
-
-      const newMessage = {
-        message: response.output,
-        sender: "bot",
-      }
-
-      setChatHistory((chatHistory) => [...chatHistory, newMessage])
+      addMessageToChatHistory(response.output, "bot")
     } catch (error) {
       console.error("Error sending message:", error)
     }
@@ -86,7 +70,7 @@ const ChatWindow = ({ onChatActivation }: Props) => {
       return
     }
 
-    setChatHistory(DEFAULT_MSG)
+    clearChatHistory()
     close()
   }
 

--- a/src/utils/useChatHistory.ts
+++ b/src/utils/useChatHistory.ts
@@ -1,0 +1,24 @@
+import { Message } from "@/types/message"
+import { DEFAULT_MSG } from "@/constant/message"
+import { useSessionStorage } from "@/utils/useSessionStorage"
+
+export const useChatHistory = () => {
+  // custom hook useSessionStorage is used to set initial value for previous chat, if there is no chat, it uses default DEFAULT_MSG as initial value. Then whenever there is new chatHistory, it is stored in sessionStorage
+  const [chatHistory, setChatHistory] = useSessionStorage<Message[]>(
+    DEFAULT_MSG,
+    "chatHistory"
+  )
+
+  const addMessageToChatHistory = (message: string, sender: string) => {
+    const newMessage = {
+      message,
+      sender: sender,
+    }
+
+    setChatHistory((chatHistory) => [...chatHistory, newMessage])
+  }
+
+  const clearChatHistory = () => setChatHistory(DEFAULT_MSG)
+
+  return { chatHistory, addMessageToChatHistory, clearChatHistory }
+}


### PR DESCRIPTION
### Issues
<!--- - List of the full links to the related Asana tickets or related PRs -->
[Asana: [FE] Get the response from API and show it on the UI as the bot's reply](https://app.asana.com/0/1207341870835443/1207415564062454/f)

<!--- For bug fix
### Reasons
- A summary to explain the cause of this issue after investigating
-->

### Updated
<!---  - Summary what did you update to fix this issue  -->
<!---  - Or a summary of what you did to implement this feature  -->
- After get a response from API, I create object and push it to chatHistory
```typescript
    const newMessage = {
      message: response.message,
      sender: "bot",
    }

    setChatHistory((chatHistory) => [...chatHistory, newMessage])
``` 

- Then I saw when user send message, it also needs to create object (with sender: "user") and push it to chatHistory. The code is similar to the code above and it also needs dependency `setChatHistory` and also `handleClearChat` need to use `setChatHistory(DEFAULT_MSG)`, so I make them into re-usable custom hook `useChatHistory`


### Result
<!-- Screenshot or video of the UI, API doc, or the result as the proof of work for this PR -->
<img width="416" alt="image" src="https://github.com/AI-ChatBot-Yoga/ai-chatbot/assets/133303660/0cf583ce-b65d-4172-a5a0-910e2e415034">


<!--- If there's a way to test this fix please list it here
### How to test
- Step 1: List all steps to test this PR
-->
