### PR TITLE
fix: add others option in DEFAULT_MSG

### DIFF
--- a/src/constant/message.ts
+++ b/src/constant/message.ts
@@ -27,6 +27,10 @@ export const DEFAULT_MSG = [
         text: " Special Care Fabric Cleaning",
         value: "Does your service provide special care fabric cleaning?",
       },
+      {
+        text: " Others",
+        value: "What other options do you have?",
+      },
     ],
   },
 ]


### PR DESCRIPTION
### Issues
<!--- - List of the full links to the related Asana tickets or related PRs -->
- [[FE] Options list: add "Others" and Change color](https://app.asana.com/0/1207458980633630/1207620593769508/f)

<!--- For bug fix
### Reasons
- A summary to explain the cause of this issue after investigating
-->

### Updated
<!---  - Summary what did you update to fix this issue  -->
<!---  - Or a summary of what you did to implement this feature  -->
- Add 'Others' option in DEFAULT_MSG

### Result
<!-- Screenshot or video of the UI, API doc, or the result as the proof of work for this PR -->
<img width="311" alt="image" src="https://github.com/AI-ChatBot-Yoga/ai-chatbot/assets/133303660/0df5a9c4-6064-401b-b4cf-51a4846d72b1">


<!--- If there's a way to test this fix please list it here
### How to test
- Step 1: List all steps to test this PR
-->