### PR TITLE
style: remove gray border for chat input in ChatWindow.tsx

### DIFF
--- a/src/components/ChatWindow/ChatWindow.module.css
+++ b/src/components/ChatWindow/ChatWindow.module.css
@@ -121,7 +121,7 @@
   top: 0;
 }
 
-.alert :global(.m-7fa78076) {
+.alert :global(.m_7fa78076) {
   color: var(--mantine-color-gray-7);
 }
 
@@ -149,7 +149,7 @@
   flex-grow: 1;
 }
 
-.textInput :global(.m-8fb7ebe7) {
+.textInput :global(.m_8fb7ebe7) {
   font-size: rem(15px);
   border: none;
 }

--- a/src/tests/test.html
+++ b/src/tests/test.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <script
+      src="../../dist/chat-widget.iife.js"
+      botid="71c0c33f-5952-43b1-8608-70bfe362f537"
+    ></script>
+  </head>
+  <body>
+    <h1>Chatbot Testing</h1>
+  </body>
+</html>


### PR DESCRIPTION
### Issues
<!--- - List of the full links to the related Asana tickets or related PRs -->
- [[FE] [10m] Remove gray border of text input](https://app.asana.com/0/1207801502231764/1207858870630141/f)

<!--- For bug fix
### Reasons
- A summary to explain the cause of this issue after investigating
-->

### Updated
<!---  - Summary what did you update to fix this issue  -->
<!---  - Or a summary of what you did to implement this feature  -->
1. In ChatWindow CSS Module, target `:global(.m_8fb7ebe7)` to remove border so that the chat input doesn't have gray border
2. Add testing page in tests folder

### Result
<!-- Screenshot or video of the UI, API doc, or the result as the proof of work for this PR -->
<img width="420" alt="image" src="https://github.com/user-attachments/assets/4668c4bc-8ae5-4c2d-b2f8-369dd319ee16">


<img width="436" alt="image" src="https://github.com/user-attachments/assets/e4274f8a-236d-4c0e-a59d-f55fa1f69803">


<!--- If there's a way to test this fix please list it here
### How to test
- Step 1: List all steps to test this PR
-->