### PR TITLE
fix independent font-size and color for project

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Chatbot Widget</title>
-
-    <style>
-      body,
-      html {
-        background-color: aquamarine;
-        font-size: 10px;
-      }
-    </style>
   </head>
   <body>
-    <h1>test</h1>
-    <p>This p has 10px by default</p>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -5,14 +5,18 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Chatbot Widget</title>
+
     <style>
       body,
       html {
         background-color: aquamarine;
+        font-size: 10px;
       }
     </style>
   </head>
   <body>
+    <h1>test</h1>
+    <p>This p has 10px by default</p>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Chatbot Widget</title>
+    <style>
+      body,
+      html {
+        background-color: aquamarine;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ChatIcon/ChatIcon.module.css
+++ b/src/components/ChatIcon/ChatIcon.module.css
@@ -1,18 +1,19 @@
 .chatIcon {
+  font-size: 16px; /* Base font size */
   cursor: pointer;
   border: unset;
   background: none;
 
   position: fixed;
-  bottom: rem(40px);
-  right: rem(30px);
+  bottom: em(40px);
+  right: em(30px);
 
   background-color: var(--mantine-color-white);
 
-  width: rem(55px);
-  height: rem(55px);
+  width: em(55px);
+  height: em(55px);
   border-radius: 50%;
-  box-shadow: 0 0 rem(10px) rem(5px) var(--mantine-yellow-vivid);
+  box-shadow: 0 0 em(10px) em(5px) var(--mantine-yellow-vivid);
 
   /* make svg center of button  */
   display: grid;
@@ -20,8 +21,8 @@
 }
 
 .chatIcon svg {
-  width: rem(35px);
-  height: rem(35px);
+  width: em(35px);
+  height: em(35px);
 }
 
 .chatIcon svg :global(.chat-icon-bg) {

--- a/src/components/ChatWindow/ChatWindow.module.css
+++ b/src/components/ChatWindow/ChatWindow.module.css
@@ -1,12 +1,17 @@
 .chatWindow {
-  max-width: rem(360px); /* Adjust height in .scrollArea */
+  all: initial; /*This resets all properties*/
+  font-family: "Roboto", sans-serif;
+  font-size: 16px; /* Base font size */
+  color: #000; /* Base text color */
+
+  max-width: em(360px); /* Adjust height in .scrollArea */
   position: fixed;
-  bottom: rem(115px);
-  margin: 0 rem(30px);
+  bottom: em(115px);
+  margin: 0 em(30px);
   right: 0;
   border: unset;
   outline: 1px solid var(--mantine-blue-medium);
-  border-radius: rem(5px);
+  border-radius: em(5px);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 }
 
@@ -14,9 +19,9 @@
 
 .chatWindowHeader {
   text-align: left;
-  padding: rem(10px);
+  padding: em(10px);
   border-bottom: 2px solid var(--mantine-blue-light);
-  height: rem(50px);
+  height: em(50px);
 
   display: flex;
   justify-content: space-between;
@@ -30,17 +35,17 @@
 .buttons {
   display: flex;
   align-items: center;
-  gap: rem(3px);
+  gap: em(3px);
 }
 
 .reloadBtn {
-  width: rem(25px);
-  height: rem(25px);
+  width: em(25px);
+  height: em(25px);
 }
 
 .closeBtn {
-  width: rem(30px);
-  height: rem(30px);
+  width: em(30px);
+  height: em(30px);
 }
 
 .reloadBtn:hover,
@@ -60,7 +65,7 @@
 /* ====== CHAT BODY ======= */
 
 .scrollArea {
-  height: rem(550px);
+  height: em(550px);
 }
 
 @media screen and (max-height: 750px) {
@@ -70,9 +75,9 @@
 }
 
 .msgBubble {
-  padding: rem(10px);
-  margin: rem(15px);
-  border-radius: rem(5px);
+  padding: em(10px);
+  margin: em(15px);
+  border-radius: em(5px);
   background-color: var(--mantine-blue-soft);
   width: fit-content;
   max-width: 85%;
@@ -88,15 +93,18 @@
 .optionsContainer {
   display: flex;
   flex-wrap: wrap;
-  margin: rem(15px);
-  gap: rem(15px 10px);
+  margin: em(15px);
+  gap: em(15px 10px);
 }
 
 .optionText {
+  height: em(36);
+  padding: 0 em(18);
+  font-size: em(14);
   color: var(--mantine-blue-vivid);
   background-color: rgba(255, 255, 255, 0.48);
   border: 1px solid var(--mantine-blue-vivid);
-  border-radius: rem(20px) !important;
+  border-radius: em(20px) !important;
 }
 
 .optionText:hover {
@@ -112,7 +120,7 @@
 
 .alert {
   background-color: var(--mantine-color-red-2);
-  padding: rem(10px);
+  padding: em(10px);
   width: 100%;
   text-align: center;
   position: absolute;
@@ -140,7 +148,7 @@
   display: flex;
   align-items: center;
   border-top: 2px solid var(--mantine-blue-light);
-  height: rem(50px);
+  height: em(50px);
 }
 
 .textInputRoot {
@@ -148,12 +156,12 @@
 }
 
 .textInput {
-  font-size: rem(15px);
+  font-size: em(15px);
   border: none;
 }
 
 .textInput input::placeholder {
-  font-size: rem(15px);
+  font-size: em(15px);
   color: #3b3b3b;
 }
 

--- a/src/components/ChatWindow/ChatWindow.module.css
+++ b/src/components/ChatWindow/ChatWindow.module.css
@@ -157,12 +157,11 @@
 }
 
 .textInput {
-  font-size: em(15px);
+  font-size: em(15);
   border: none;
 }
 
 .textInput input::placeholder {
-  font-size: em(15px);
   color: #3b3b3b;
 }
 

--- a/src/components/ChatWindow/ChatWindow.module.css
+++ b/src/components/ChatWindow/ChatWindow.module.css
@@ -3,6 +3,7 @@
   font-family: "Roboto", sans-serif;
   font-size: 16px; /* Base font size */
   color: #000; /* Base text color */
+  background-color: #fff;
 
   max-width: em(360px); /* Adjust height in .scrollArea */
   position: fixed;

--- a/src/components/ConfirmationModal/ConfirmationModal.module.css
+++ b/src/components/ConfirmationModal/ConfirmationModal.module.css
@@ -9,10 +9,10 @@
 }
 
 .modalContent p {
-  font-size: rem(18px);
+  font-size: em(18px);
   margin-top: 0;
-  margin-right: rem(20px);
-  margin-bottom: rem(20px);
+  margin-right: em(20px);
+  margin-bottom: em(20px);
   font-weight: 300;
 }
 
@@ -31,7 +31,7 @@
   overflow: visible;
   color: black;
   font-weight: 300;
-  font-size: rem(18px);
+  font-size: em(18px);
 }
 
 .btnYes:hover {
@@ -43,8 +43,8 @@
 }
 
 .closeBtn svg {
-  width: rem(30px);
-  height: rem(30px);
+  width: em(30px);
+  height: em(30px);
   color: black;
 }
 

--- a/src/components/ConfirmationModal/ConfirmationModal.module.css
+++ b/src/components/ConfirmationModal/ConfirmationModal.module.css
@@ -8,6 +8,14 @@
   max-width: fit-content;
 }
 
+.modalHeader {
+  padding: em(16) em(11) em(16) em(16);
+}
+
+.modalBody {
+  padding: 0 em(16) em(16) em(16);
+}
+
 .modalContent p {
   font-size: em(18px);
   margin-top: 0;
@@ -33,6 +41,11 @@
   font-weight: 300;
   font-size: em(18px);
 }
+.btnYes,
+.btnNo {
+  font-size: 16px;
+  padding: em(18);
+}
 
 .btnYes:hover {
   background-color: var(--mantine-blue-vivid);
@@ -42,9 +55,14 @@
   background-color: var(--mantine-yellow-vivid);
 }
 
+.closeBtn {
+  font-size: 16px;
+  width: em(30);
+}
+
 .closeBtn svg {
-  width: em(30px);
-  height: em(30px);
+  width: em(30);
+  height: em(30);
   color: black;
 }
 

--- a/src/components/ConfirmationModal/ConfirmationModal.module.css
+++ b/src/components/ConfirmationModal/ConfirmationModal.module.css
@@ -17,7 +17,7 @@
 }
 
 .modalContent p {
-  font-size: em(18px);
+  font-size: em(18);
   margin-top: 0;
   margin-right: em(20px);
   margin-bottom: em(20px);
@@ -39,7 +39,6 @@
   overflow: visible;
   color: black;
   font-weight: 300;
-  font-size: em(18px);
 }
 .btnYes,
 .btnNo {
@@ -56,7 +55,6 @@
 }
 
 .closeBtn {
-  font-size: 16px;
   width: em(30);
 }
 

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -24,6 +24,8 @@ const ConfirmationModal = ({
         overlay: styles.modalOverlay,
         inner: styles.modalInner,
         content: styles.modalContent,
+        header: styles.modalHeader,
+        body: styles.modalBody,
         close: styles.closeBtn,
       }}
       withinPortal={false}

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -19,7 +19,7 @@ const ConfirmationModal = ({
       title={<Title order={4}>Restart Chat</Title>}
       opened={openedModal}
       onClose={close}
-      size="16rem"
+      size="16em"
       classNames={{
         overlay: styles.modalOverlay,
         inner: styles.modalInner,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import {
   MantineProvider,
   createTheme,
   CSSVariablesResolver,
-  rem,
+  em,
 } from "@mantine/core"
 
 /* 
@@ -15,13 +15,13 @@ theme.colors object is required to have 10 shades. So I use Mantine's CSS variab
 const theme = createTheme({
   /** Your theme override here */
   fontFamily: "Roboto, sans-serif",
-  fontSizes: { md: rem(15) },
+  fontSizes: { md: em(15) },
   headings: {
     fontFamily: "Roboto, sans-serif",
     sizes: {
       h4: {
         fontWeight: "400",
-        fontSize: rem(20),
+        fontSize: em(20),
       },
     },
   },


### PR DESCRIPTION
### Issues
<!--- - List of the full links to the related Asana tickets or related PRs -->
- [[P2][FE] Check font size, style & color conflicts when embedding on other websites](https://app.asana.com/0/1208138780222980/1207590834247077/f)

### Reasons
**Bug**: Fix `font-size` and `color` of chatbot inherits styling when embedding to another website

**Impact**: This bug causes an error that when embed the chatbot to any website, it will inherit `font-size` and `color` of that website. Causing inconsistent of chatbot's design. Also it will affect `height` and `width` since some element use `rem` units (Mantine's default value)

**Implement suggestion**: Switch to `iframe` to make styling 100% independent. If customer's website set code like below, the `text-color` will also affect
```css
  * {
        color: red;
      }
``` 

### Updated
<!---  - Summary what did you update to fix this issue  -->
<!---  - Or a summary of what you did to implement this feature  -->
1. Declare base value (`font-size`, `color`, `background-color`,...) on components' parent element (`. chatIcon` and `.chatWindow')
2. Convert all `rem` into `em` (since rem will use root value => if website declare `font-size` in root will cause inconsistent in chatbot's design). That's why we use `em` so that it will look up to its parent element
3. In Mantine CSS, some elements will have `height`, `width`, `padding` and `margin` defined in `rem`. Use '[Styles API](https://mantine.dev/core/modal/?t=styles-api)' to manually declare value 

### Result
<!-- Screenshot or video of the UI, API doc, or the result as the proof of work for this PR -->
Example 1: Chatbot inherits `color: white` from the website
Before: 
![image](https://github.com/user-attachments/assets/f6c787cc-60ca-432c-9639-20c03b726db3)

After:
![image](https://github.com/user-attachments/assets/d69c878e-851f-4293-a58c-032dac1f60d0)

Example 2: Chatbot inherits `font-size: 10px` from the website
Before: 
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/f867f690-857f-4eb5-a862-f6a9ff158a59">

After:
<img width="1475" alt="image" src="https://github.com/user-attachments/assets/04dcb725-1a9c-41e6-99a4-64221f2ae596">



<!--- If there's a way to test this fix please list it here
### How to test
- Step 1: List all steps to test this PR
-->