### PR TITLE
style: make PopupMessage's style dependently

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>AI Chatbot Widget</title>
+
+    <!-- Uncomment this to check if UI still depend on customer's style -->
+    <!-- <style>
+      html {
+        font-size: 10px;
+      }
+      body {
+        color: red;
+      }
+    </style> -->
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ChatIcon/ChatIcon.module.css
+++ b/src/components/ChatIcon/ChatIcon.module.css
@@ -1,5 +1,5 @@
 .chatIcon {
-  font-size: 16px; /* Base font size */
+  font-size: var(--mantine-base-font-size);
   cursor: pointer;
   border: unset;
   background: none;

--- a/src/components/ChatWindow/ChatWindow.module.css
+++ b/src/components/ChatWindow/ChatWindow.module.css
@@ -1,7 +1,7 @@
 .chatWindow {
   all: initial; /*This resets all properties*/
   font-family: "Roboto", sans-serif;
-  font-size: 16px; /* Base font size */
+  font-size: var(--mantine-base-font-size);
   color: var(--mantine-text-color);
   background-color: #fff;
 

--- a/src/components/ConfirmationModal/ConfirmationModal.module.css
+++ b/src/components/ConfirmationModal/ConfirmationModal.module.css
@@ -46,7 +46,7 @@
 }
 .btnYes,
 .btnNo {
-  font-size: 16px;
+  font-size: var(--mantine-base-font-size);
   padding: em(18);
 }
 

--- a/src/components/PopupMessage/PopupMessage.module.css
+++ b/src/components/PopupMessage/PopupMessage.module.css
@@ -1,4 +1,5 @@
 .popupMessageRoot {
+  font-size: var(--mantine-base-font-size);
   position: fixed;
   bottom: em(120px);
   right: em(30px);
@@ -17,5 +18,6 @@
 }
 
 .popupMessageMessage {
+  font-size: em(14px);
   color: var(--mantine-text-color);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,7 @@ theme.colors object is required to have 10 shades. So I use Mantine's CSS variab
 const theme = createTheme({
   /** Your theme override here */
   fontFamily: "Roboto, sans-serif",
-  fontSizes: { md: em(15) },
+  fontSizes: { md: "15px", base: "16px" },
   headings: {
     fontFamily: "Roboto, sans-serif",
     sizes: {
@@ -51,6 +51,7 @@ const resolver: CSSVariablesResolver = (theme) => ({
     "--mantine-light-gray": theme.other.lightGray,
     "--mantine-dark-gray": theme.other.darkGray,
     "--mantine-text-color": theme.other.textColor,
+    "--mantine-base-font-size": theme.fontSizes.base,
   },
   light: {},
   dark: {},


### PR DESCRIPTION
### Issues
<!--- - List of the full links to the related Asana tickets or related PRs -->
- [[FE] Make PopupMessage's style dependently](https://app.asana.com/0/1208530409762007/1208645148052425/f)

### Reasons
- Currently, `PopupMessage` is still dependent on customer's default font style. Fix this bug

### Updated
<!---  - Summary what did you update to fix this issue  -->
<!---  - Or a summary of what you did to implement this feature  -->
- Declare base `font-size` in `main.tst`. Use this CSS Variable to update on each component's CSS Module. Now the project is base on default font from parent container rather than website's default style

### Result
<!-- Screenshot or video of the UI, API doc, or the result as the proof of work for this PR -->
- Before: 
![image](https://github.com/user-attachments/assets/10b87389-c89f-409c-92aa-0dc409257b62)

- After:
![image](https://github.com/user-attachments/assets/09f47a22-b894-4359-a8b1-4860a14af531)


<!--- If there's a way to test this fix please list it here
### How to test
- Step 1: List all steps to test this PR
-->